### PR TITLE
Feature/add estop

### DIFF
--- a/rr_viz/src/ross/estop/emergency_stop.py
+++ b/rr_viz/src/ross/estop/emergency_stop.py
@@ -5,6 +5,7 @@ from PyQt5.QtCore import Qt
 
 import rospy
 from std_srvs.srv import SetBool, SetBoolRequest
+from std_msgs.msg import Bool
 
 class EmergencyStop(QWidget):
     def __init__(self, parent):
@@ -42,6 +43,10 @@ class EmergencyStop(QWidget):
         self.eStop_srv_name = '/emergency_stop/trigger_eStop'
         self.eStop_srv = rospy.ServiceProxy(self.eStop_srv_name, SetBool)
         self.eStop_req = SetBoolRequest()
+
+        # Set up subscriber
+        self.eStop_status_topic_name = '/emergency_stop/status'
+        self.eStop_status_sub = rospy.Subscriber(self.eStop_status_topic_name, Bool, self.eStop_status_update)
 
     def enable_eStop(self):
         self.eStop_req.data = True
@@ -82,3 +87,15 @@ class EmergencyStop(QWidget):
         except:
             msg = "Service '" + self.eStop_srv_name + "' unavailable"
             rospy.logwarn(msg)
+
+    def eStop_status_update(self, msg):
+        if msg.data:
+            self.enable_eStop_button.setStyleSheet("")
+            self.disable_eStop_button.setStyleSheet("color: white;"
+                                                    "background-color: green;"
+                                                    "font-weight: bold;")
+        else:
+            self.enable_eStop_button.setStyleSheet("color: white;"
+                                                    "background-color: red;"
+                                                    "font-weight: bold;")
+            self.disable_eStop_button.setStyleSheet("")      

--- a/rr_viz/src/ross/estop/emergency_stop.py
+++ b/rr_viz/src/ross/estop/emergency_stop.py
@@ -16,7 +16,7 @@ class EmergencyStop(QWidget):
         # Set up service
         self.eStop_srv_name = '/emergency_stop/trigger_eStop'
         self.eStop_srv = rospy.ServiceProxy(self.eStop_srv_name, SetBool)
-        self.eStop_req = SetBoolRequest()
+
         self.eStop_srv_timer = rospy.Timer(rospy.Duration(
             1), self.ping_srv)
         self.eStop_srv_connected = False
@@ -65,21 +65,22 @@ class EmergencyStop(QWidget):
                                    "Lost Connection to {}".format(self.eStop_srv_name) if self.eStop_srv_connected else "Failed to connect to {}".format(self.eStop_srv_name))
             self.eStop_srv_connected = False
 
-        
         self.layout_estop_enable_btn(False)
         self.layout_estop_disable_btn(False)
 
     def enable_eStop(self):
-        self.eStop_req.data = True
-        self.trigger_service()
+        eStop_req = SetBoolRequest()
+        eStop_req.data = True
+        self.trigger_service(eStop_req)
 
     def disable_eStop(self):
-        self.eStop_req.data = False
-        self.trigger_service()
+        eStop_req = SetBoolRequest()
+        eStop_req.data = False
+        self.trigger_service(eStop_req)
 
-    def trigger_service(self):
+    def trigger_service(self, req):
         try:
-            trig_resp = self.eStop_srv.call(self.eStop_req)
+            trig_resp = self.eStop_srv.call(req)
             rospy.loginfo(trig_resp.message)
             if not trig_resp.success:
                 msg = "Failed to call '" + self.eStop_srv_name + "' service"
@@ -101,8 +102,8 @@ class EmergencyStop(QWidget):
             self.layout_estop_disable_btn(False)
              
 
-    def layout_estop_enable_btn(self, state):
-        if state:
+    def layout_estop_enable_btn(self, enabled):
+        if enabled:
             self.enable_eStop_button.setEnabled(True)
             self.enable_eStop_button.setStyleSheet("color: white;"
                                                     "background-color: red;"
@@ -111,8 +112,8 @@ class EmergencyStop(QWidget):
             self.enable_eStop_button.setEnabled(False)
             self.enable_eStop_button.setStyleSheet("")
 
-    def layout_estop_disable_btn(self, state):
-        if state:
+    def layout_estop_disable_btn(self, enabled):
+        if enabled:
             self.disable_eStop_button.setEnabled(True)
             self.disable_eStop_button.setStyleSheet("color: white;"
                                     "background-color: green;"

--- a/rr_viz/src/ross/mission_dashboard/emergency_stop.py
+++ b/rr_viz/src/ross/mission_dashboard/emergency_stop.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+from PyQt5.QtWidgets import QVBoxLayout, QWidget, QLabel, QPushButton, QHBoxLayout
+from PyQt5.QtGui import QFont
+from PyQt5.QtCore import Qt
+
+import rospy
+from std_srvs.srv import Trigger, TriggerRequest
+
+class EmergencyStop(QWidget):
+    def __init__(self, parent):
+        super(QWidget, self).__init__(parent)
+
+        self.v_layout = QVBoxLayout()
+
+        # Title
+        self.title_label = QLabel('Emergency Stop')
+        self.title_label.setFont(QFont('Ubuntu', 11, QFont.Bold))
+        self.title_label.setAlignment(Qt.AlignRight)
+        self.v_layout.addWidget(self.title_label)
+        
+        # Buttons
+        self.h_layout = QHBoxLayout()
+        self.enable_eStop_button = QPushButton('Emergency Stop')
+        self.enable_eStop_button.pressed.connect(self.enable_eStop)
+
+        self.disable_eStop_button = QPushButton('Reset Emergency Stop')
+        self.disable_eStop_button.pressed.connect(self.disable_eStop)
+
+        self.disable_eStop_button.setEnabled(False)
+
+        self.h_layout.addWidget(self.enable_eStop_button)
+        self.h_layout.addWidget(self.disable_eStop_button)
+
+        self.v_layout.addLayout(self.h_layout)
+
+        self.setLayout(self.v_layout)
+
+    def enable_eStop(self):
+        self.enable_eStop_button.setEnabled(False)
+        self.disable_eStop_button.setEnabled(True)
+
+    def disable_eStop(self):
+        self.enable_eStop_button.setEnabled(True)
+        self.disable_eStop_button.setEnabled(False)

--- a/rr_viz/src/ross/mission_dashboard/emergency_stop.py
+++ b/rr_viz/src/ross/mission_dashboard/emergency_stop.py
@@ -4,7 +4,7 @@ from PyQt5.QtGui import QFont
 from PyQt5.QtCore import Qt
 
 import rospy
-from std_srvs.srv import Trigger, TriggerRequest
+from std_srvs.srv import SetBool, SetBoolRequest
 
 class EmergencyStop(QWidget):
     def __init__(self, parent):
@@ -35,10 +35,40 @@ class EmergencyStop(QWidget):
 
         self.setLayout(self.v_layout)
 
+        # Set up service
+        self.eStop_srv_name = '/emergency_stop/trigger_eStop'
+        self.eStop_srv = rospy.ServiceProxy(self.eStop_srv_name, SetBool)
+        self.eStop_req = SetBoolRequest()
+
     def enable_eStop(self):
-        self.enable_eStop_button.setEnabled(False)
-        self.disable_eStop_button.setEnabled(True)
+        self.eStop_req.data = True
+
+        try:
+            trig_resp = self.eStop_srv.call(self.eStop_req)
+            rospy.loginfo(trig_resp.message)
+            if not trig_resp.success:
+                msg = "Failed to call '" + self.eStop_srv_name + "' service"
+                rospy.logerr(msg)
+            else:
+                self.enable_eStop_button.setEnabled(False)
+                self.disable_eStop_button.setEnabled(True)
+        except:
+            msg = "Service '" + self.eStop_srv_name + "' unavailable"
+            rospy.logwarn(msg)
+
 
     def disable_eStop(self):
-        self.enable_eStop_button.setEnabled(True)
-        self.disable_eStop_button.setEnabled(False)
+        self.eStop_req.data = False
+
+        try:
+            trig_resp = self.eStop_srv.call(self.eStop_req)
+            rospy.loginfo(trig_resp.message)
+            if not trig_resp.success:
+                msg = "Failed to call '" + self.eStop_srv_name + "' service"
+                rospy.logerr(msg)
+            else:
+                self.enable_eStop_button.setEnabled(True)
+                self.disable_eStop_button.setEnabled(False)
+        except:
+            msg = "Service '" + self.eStop_srv_name + "' unavailable"
+            rospy.logwarn(msg)

--- a/rr_viz/src/ross/mission_dashboard/emergency_stop.py
+++ b/rr_viz/src/ross/mission_dashboard/emergency_stop.py
@@ -21,6 +21,9 @@ class EmergencyStop(QWidget):
         # Buttons
         self.h_layout = QHBoxLayout()
         self.enable_eStop_button = QPushButton('Emergency Stop')
+        self.enable_eStop_button.setStyleSheet("color: white;"
+                                                "background-color: red;"
+                                                "font-weight: bold;")
         self.enable_eStop_button.pressed.connect(self.enable_eStop)
 
         self.disable_eStop_button = QPushButton('Reset Emergency Stop')
@@ -51,11 +54,14 @@ class EmergencyStop(QWidget):
                 rospy.logerr(msg)
             else:
                 self.enable_eStop_button.setEnabled(False)
+                self.enable_eStop_button.setStyleSheet("")
                 self.disable_eStop_button.setEnabled(True)
+                self.disable_eStop_button.setStyleSheet("color: white;"
+                                        "background-color: green;"
+                                        "font-weight: bold;")
         except:
             msg = "Service '" + self.eStop_srv_name + "' unavailable"
             rospy.logwarn(msg)
-
 
     def disable_eStop(self):
         self.eStop_req.data = False
@@ -68,7 +74,11 @@ class EmergencyStop(QWidget):
                 rospy.logerr(msg)
             else:
                 self.enable_eStop_button.setEnabled(True)
+                self.enable_eStop_button.setStyleSheet("color: white;"
+                                                        "background-color: red;"
+                                                        "font-weight: bold;")
                 self.disable_eStop_button.setEnabled(False)
+                self.disable_eStop_button.setStyleSheet("")
         except:
             msg = "Service '" + self.eStop_srv_name + "' unavailable"
             rospy.logwarn(msg)

--- a/rr_viz/src/ross/mission_dashboard/mission_dashboard.py
+++ b/rr_viz/src/ross/mission_dashboard/mission_dashboard.py
@@ -5,7 +5,7 @@ from PyQt5.QtGui import QFont
 from docking import Docking
 from path_navigation_tools import PathNavigationTools
 from mission_controls import MissionControls
-from emergency_stop import EmergencyStop
+from ..estop.emergency_stop import EmergencyStop
 
 class MissionDashboard(QWidget):
     def __init__(self, parent):

--- a/rr_viz/src/ross/mission_dashboard/mission_dashboard.py
+++ b/rr_viz/src/ross/mission_dashboard/mission_dashboard.py
@@ -5,6 +5,7 @@ from PyQt5.QtGui import QFont
 from docking import Docking
 from path_navigation_tools import PathNavigationTools
 from mission_controls import MissionControls
+from emergency_stop import EmergencyStop
 
 class MissionDashboard(QWidget):
     def __init__(self, parent):
@@ -15,7 +16,7 @@ class MissionDashboard(QWidget):
         # Docking set up
         self.docking_widget = Docking(self)
 
-        self.v_layout.addWidget(self.docking_widget, 2)
+        self.v_layout.addWidget(self.docking_widget, 1)
 
         self.line = QFrame()
         self.line.setFrameShape(QFrame.HLine)
@@ -25,7 +26,7 @@ class MissionDashboard(QWidget):
 
         # Path navigation tools set up
         self.path_navigation_tools_widget = PathNavigationTools(self)
-        self.v_layout.addWidget(self.path_navigation_tools_widget,4)
+        self.v_layout.addWidget(self.path_navigation_tools_widget, 4)
 
         self.line2 = QFrame()
         self.line2.setFrameShape(QFrame.HLine)
@@ -36,5 +37,15 @@ class MissionDashboard(QWidget):
         # Mission controls set up
         self.mission_controls_widget = MissionControls(self)
         self.v_layout.addWidget(self.mission_controls_widget, 4)       
+
+        self.line3 = QFrame()
+        self.line3.setFrameShape(QFrame.HLine)
+        self.line3.setFrameShadow(QFrame.Sunken)
+
+        self.v_layout.addWidget(self.line3)
+
+        # Emergency stop set up
+        self.emergency_stop_widget = EmergencyStop(self)
+        self.v_layout.addWidget(self.emergency_stop_widget, 1)
 
         self.setLayout(self.v_layout)

--- a/rr_viz/src/ross/mission_editor/mission_editor.py
+++ b/rr_viz/src/ross/mission_editor/mission_editor.py
@@ -14,6 +14,7 @@ import string
 
 from rr_custom_msgs.srv import BuildBT
 from mission_actions import BuildBTAction, WaypointMoveBaseAction
+from ..estop.emergency_stop import EmergencyStop
 
 class MissionEditor(QWidget):
     # Set up signals
@@ -107,6 +108,9 @@ class MissionEditor(QWidget):
         self.h_layout_command.addWidget(self.send_mission_button)
 
         self.v_layout.addLayout(self.h_layout_command)
+
+        self.emergency_stop_widget = EmergencyStop(self)
+        self.v_layout.addWidget(self.emergency_stop_widget)
 
         self.setLayout(self.v_layout)
 


### PR DESCRIPTION
This PR adds the eStop functionality to both mission editor tab and mission dashboard tab.

To test use feature/rr_viz_estop in ross_robo repo :
- roscore
- rosrun rr_locomotion emergency_stop.py
- roslaunch rr_viz rr_viz.launch

You should see that on both tabs the eStop button is red with bold, white writing and the reset button is greyed out. 
When you click the eStop button and the service trigger is successful the eStop button should become grey out and the rest button become green with bold white writing. 
At this point if you switch to the other tab the buttons should be in the same state.
When you click the reset button and the service trigger is successful the buttons should return the their original state
If the service is unavailable neither buttons are enabled