### PR TITLE
fix rr_viz crashing

### DIFF
--- a/rr_viz/README.md
+++ b/rr_viz/README.md
@@ -40,16 +40,3 @@ As a placeholder I've added a launch file for rviz textured sphere (a submodule 
 To configure rviz textured sphere you can change the topic names and image transport, fov of every camera and blend angle. Make sure that the image feed that you use is cropped to only contain a square with the camera fisheye view.
 My prefered method of tuning the view is to add the camera topics and then look at the line where the two views are joined. Then I modify the fov of two cameras to get the two images to merge nicely in the intersection section.
 In some cases the cameras won't be perfectly symmetric so please make sure you get a good overlap on all sides of 360 rig.
-
-## fping
-RRVIZ requires fping to be installed on the ocu
-To do this use:
-pip install fping
-
-and then follow the instructions on the following link
-https://github.com/NetworkEng/fping/tree/csv 
-
-fping: Version 3.13csv
-
-
-On the github instructions I followed the IPv6 support 

--- a/rr_viz/src/ross/esm/environmental_sensing_module.py
+++ b/rr_viz/src/ross/esm/environmental_sensing_module.py
@@ -69,6 +69,7 @@ class EnvironmentalSensingModule(QWidget):
         self.vis_topic_sub = rospy.Subscriber(self.vis_topic_name, Illuminance, self.vis_update)
 
         self.degree_symbol = u'\N{DEGREE SIGN}'
+        
     def ir_update(self, msg):
         self.ir_data_label.setText("IR: " + format(msg.illuminance, ".2f") + " Lux")
 

--- a/rr_viz/src/ross/rr_interactive_tools.py
+++ b/rr_viz/src/ross/rr_interactive_tools.py
@@ -12,13 +12,13 @@ class RRInteractiveTools(QWidget):
         self.layout = QVBoxLayout()
 
         self.tabs = QTabWidget()
-        self.mission_dashboard_tab = QWidget()
+        # self.mission_dashboard_tab = QWidget()
         self.mission_editor_tab = QWidget()
         self.slam_supervisor_tab = QWidget()
 
         self.tabs.addTab(self.mission_editor_tab, "Mission Editor")
         self.tabs.addTab(self.slam_supervisor_tab, "Slam Supervisor")
-        self.tabs.addTab(self.mission_dashboard_tab, "Mission Dashboard")
+        # self.tabs.addTab(self.mission_dashboard_tab, "Mission Dashboard")
         
         self.mission_editor_tab.layout = QVBoxLayout()
         self.mission_editor_tab.layout.addWidget(MissionEditor(self))
@@ -28,9 +28,9 @@ class RRInteractiveTools(QWidget):
         self.slam_supervisor_tab.layout.addWidget(SlamSupervisor(self))
         self.slam_supervisor_tab.setLayout(self.slam_supervisor_tab.layout)
 
-        self.mission_dashboard_tab.layout = QVBoxLayout()
-        self.mission_dashboard_tab.layout.addWidget(MissionDashboard(self))
-        self.mission_dashboard_tab.setLayout(self.mission_dashboard_tab.layout)
+        # self.mission_dashboard_tab.layout = QVBoxLayout()
+        # self.mission_dashboard_tab.layout.addWidget(MissionDashboard(self))
+        # self.mission_dashboard_tab.setLayout(self.mission_dashboard_tab.layout)
 
         self.layout.addWidget(self.tabs)
         self.setLayout(self.layout)

--- a/rr_viz/src/ross/rr_interactive_tools.py
+++ b/rr_viz/src/ross/rr_interactive_tools.py
@@ -12,13 +12,13 @@ class RRInteractiveTools(QWidget):
         self.layout = QVBoxLayout()
 
         self.tabs = QTabWidget()
-        # self.mission_dashboard_tab = QWidget()
+        self.mission_dashboard_tab = QWidget()
         self.mission_editor_tab = QWidget()
         self.slam_supervisor_tab = QWidget()
 
         self.tabs.addTab(self.mission_editor_tab, "Mission Editor")
         self.tabs.addTab(self.slam_supervisor_tab, "Slam Supervisor")
-        # self.tabs.addTab(self.mission_dashboard_tab, "Mission Dashboard")
+        self.tabs.addTab(self.mission_dashboard_tab, "Mission Dashboard")
         
         self.mission_editor_tab.layout = QVBoxLayout()
         self.mission_editor_tab.layout.addWidget(MissionEditor(self))
@@ -28,9 +28,9 @@ class RRInteractiveTools(QWidget):
         self.slam_supervisor_tab.layout.addWidget(SlamSupervisor(self))
         self.slam_supervisor_tab.setLayout(self.slam_supervisor_tab.layout)
 
-        # self.mission_dashboard_tab.layout = QVBoxLayout()
-        # self.mission_dashboard_tab.layout.addWidget(MissionDashboard(self))
-        # self.mission_dashboard_tab.setLayout(self.mission_dashboard_tab.layout)
+        self.mission_dashboard_tab.layout = QVBoxLayout()
+        self.mission_dashboard_tab.layout.addWidget(MissionDashboard(self))
+        self.mission_dashboard_tab.setLayout(self.mission_dashboard_tab.layout)
 
         self.layout.addWidget(self.tabs)
         self.setLayout(self.layout)

--- a/rr_viz/src/rr_viz_tabs.py
+++ b/rr_viz/src/rr_viz_tabs.py
@@ -43,7 +43,7 @@ class RRVizTabs(QWidget):
         
         self.connection_status = QLabel('Lost')
         self.connection_status.setFont(QFont('Ubuntu', 14, QFont.Bold))
-        self.connection_status.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.connection_status.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         self.battery_label = QLabel('Battery Level:')
         self.battery_label.setFont(QFont('Ubuntu', 14, QFont.Bold))

--- a/rr_viz/src/rr_viz_tabs.py
+++ b/rr_viz/src/rr_viz_tabs.py
@@ -102,17 +102,19 @@ class RRVizTabs(QWidget):
         self.timer.start(self.timer_period)
 
     def ros_is_up(self):
-        process = subprocess.Popen(self.subprocess_command, shell=True, stdout=subprocess.PIPE)
-        stdout = process.communicate()[0]
-
-        if not self.fp_status in stdout and not self.ros_loss_triggered:
-            self.connection_status.setText("Connection lost")
-            self.connection_status.setStyleSheet("color: red")
-            self.ros_loss_triggered = True
-        elif self.fp_status in stdout and self.ros_loss_triggered:
             self.connection_status.setText("Connected")
             self.connection_status.setStyleSheet("color: green")
-            self.ros_loss_triggered = False
+        # process = subprocess.Popen(self.subprocess_command, shell=True, stdout=subprocess.PIPE)
+        # stdout = process.communicate()[0]
+
+        # if not self.fp_status in stdout and not self.ros_loss_triggered:
+        #     self.connection_status.setText("Connection lost")
+        #     self.connection_status.setStyleSheet("color: red")
+        #     self.ros_loss_triggered = True
+        # elif self.fp_status in stdout and self.ros_loss_triggered:
+        #     self.connection_status.setText("Connected")
+        #     self.connection_status.setStyleSheet("color: green")
+        #     self.ros_loss_triggered = False
 
     def battery_level_update(self, msg):
         bat_level = format(msg.voltage, ".1f") + 'V'

--- a/rr_viz/src/rr_viz_tabs.py
+++ b/rr_viz/src/rr_viz_tabs.py
@@ -113,8 +113,7 @@ class RRVizTabs(QWidget):
 
     def core_clock_cb(self, msg):
         self.read_time = msg
-        
-
+       
     def ros_is_up(self):
         if self.last_received_time.data.secs == 0:
             self.last_received_time = self.read_time

--- a/rr_viz/src/rr_viz_tabs.py
+++ b/rr_viz/src/rr_viz_tabs.py
@@ -149,7 +149,7 @@ class RRVizTabs(QWidget):
         if(self.no_time_change <= 3):
             self.connection_status.setText("Good")
             self.connection_status.setStyleSheet("color: green")
-        elif self.no_time_change > 3 and self.no_time_change <= 5: 
+        elif self.no_time_change > 3:
             self.connection_status.setText("Poor")
             self.connection_status.setStyleSheet("color: orange")
         else:

--- a/rr_viz/src/rr_viz_tabs.py
+++ b/rr_viz/src/rr_viz_tabs.py
@@ -107,21 +107,17 @@ class RRVizTabs(QWidget):
         self.read_time = RosTime()
         self.no_time_change = 0
         freq = float(self.clock_freq) * 2
-        self.timer_dur = rospy.Duration(1.0 / freq)
+        self.timer_period = 1.0 / freq
 
         # Connection callbacks
         self.clock_sub = rospy.Subscriber(self.clock_topic, Clock, self.clock_cb)
-        self.timer = rospy.Timer(self.timer_dur, self.clock_timer_cb, oneshot = True)
+        self.timer = QTimer.singleShot(self.timer_period, self.clock_timer_cb)
 
-    def clock_timer_cb(self, event):
-        freq = float(self.clock_freq) * 2
-        self.timer_dur = rospy.Duration(1.0 / freq)
-        self.timer = rospy.Timer(self.timer_dur, self.clock_timer_cb, oneshot = True)
 
+    def clock_timer_cb(self):
         if self.first_value:
             self.last_received_time.data = self.read_time.data
             self.first_value = False            
-            return
         elif not self.first_value and self.get_first_msg:
             time_diff = (self.read_time.data - self.last_received_time.data).to_sec()
  
@@ -142,7 +138,11 @@ class RRVizTabs(QWidget):
             elif self.latency >= self.poor_connection_threshold and self.latency < self.lost_connection_threshold:
                 self.connection_status.setText("Poor")
             
-            self.last_received_time.data = self.read_time.data    
+            self.last_received_time.data = self.read_time.data   
+
+        freq = float(self.clock_freq) * 2
+        self.timer_period = 1.0 / freq
+        self.timer = QTimer.singleShot(self.timer_period, self.clock_timer_cb) 
         
     def clock_cb(self, msg):
         self.clock_freq = msg.update_rate

--- a/rr_viz/src/rr_viz_tabs.py
+++ b/rr_viz/src/rr_viz_tabs.py
@@ -105,6 +105,10 @@ class RRVizTabs(QWidget):
 
         # Core timer
         core_clock_pub_freq = rospy.get_param("~publish_frequency", 10)
+
+        # To calculate the period for the timer to monitor if the clock cb times out we want the timer to timeout after an 
+        # additional 10%. As this maths is being done as a frequency the 10% needs to be subtracted so that on the following line
+        # the period ends up being 10% longer than the clock publishing
         freq = float(core_clock_pub_freq) - (float(core_clock_pub_freq) / 100 * 10)
         self.core_clock_timer_dur = rospy.Duration(1.0 / freq)
         self.core_clock_timer = rospy.Timer(self.core_clock_timer_dur, self.core_clock_timer_cb, oneshot = True)

--- a/rr_viz/src/rr_viz_tabs.py
+++ b/rr_viz/src/rr_viz_tabs.py
@@ -95,7 +95,7 @@ class RRVizTabs(QWidget):
         self.battery_level_sub = rospy.Subscriber(self.battery_level_sub_name, BatteryState, self.battery_level_update)
 
         # Set up core connection variables
-        self.core_clock_sub_name = rospy.get_param("/core_clock_sub","/clock")
+        self.core_clock_sub_name = rospy.get_param("/core_clock_sub","/mk3_core/clock")
         self.core_clock_sub = rospy.Subscriber(self.core_clock_sub_name, Clock, self.core_clock_cb)
         self.last_received_time = RosTime()
 

--- a/rr_viz/src/rr_viz_tabs.py
+++ b/rr_viz/src/rr_viz_tabs.py
@@ -91,23 +91,17 @@ class RRVizTabs(QWidget):
         self.battery_state = False
 
         # Set up topic subscribers
-        self.battery_level_sub_name = "/vesc_driver/battery"
+        self.battery_level_sub_name = rospy.get_param("/battery/level", "/vesc_driver/battery")
         self.battery_level_sub = rospy.Subscriber(self.battery_level_sub_name, BatteryState, self.battery_level_update)
 
         # Set up core connection variables
-        self.core_clock_sub_name ="/core_clock_publisher/clock"
+        self.core_clock_sub_name = rospy.get_param("/core_clock_sub","/core_clock_publisher/clock")
         self.core_clock_sub = rospy.Subscriber(self.core_clock_sub_name, Time, self.core_clock_cb)
         self.last_received_time = Time()
 
         self.read_time = Time()
         self.no_time_change = 0
         self.latch = 0
-
-        # Variables required to detect if connected to ROS MASTER
-        self.ros_loss_triggered = True
-        self.rosMasterIP = '192.168.10.100'
-        self.subprocess_command = 'fping -nV -t 50 ' + self.rosMasterIP
-        self.fp_status = "alive"  
 
         # Set up timer 
         self.timer_period = 1000

--- a/rr_viz/src/rr_viz_tabs.py
+++ b/rr_viz/src/rr_viz_tabs.py
@@ -101,18 +101,18 @@ class RRVizTabs(QWidget):
 
         # Core timer
         core_clock_pub_freq = rospy.get_param("~publish_frequency", 10)
-
+        self.first_value = False
+        self.get_first_msg = False
+        self.latency = 0
+        self.read_time = RosTime()
+        self.no_time_change = 0
+        
         #Set the frequency of the timer to be twice as fast as the clock frequency
         freq = float(core_clock_pub_freq) * 2
         self.core_clock_timer_dur = rospy.Duration(1.0 / freq)
         self.core_clock_timer = rospy.Timer(self.core_clock_timer_dur, self.core_clock_timer_cb, oneshot = True)
         self.poor_connection_threshold = rospy.get_param("/core_clock_poor_connection", 3)
         self.lost_connection_threshold = rospy.get_param("/core_clock_lost_connection", 5)
-        self.first_value = False
-        self.get_first_msg = False
-        self.latency = 0
-        self.read_time = RosTime()
-        self.no_time_change = 0
      
         self.low_battery_popup.connect(self.bat_message_popup)
 


### PR DESCRIPTION
This PR fixes rr_viz randomly crashing without any reason. It was caused by updating the stylesheet of a label multiple times in quick procession. To fix this I removed the colour setting on the battery level and replaced it with a pop up dialog to tell the user when the battery is low. Also in this PR I replaced how rr_viz determines it is still connected to the roscore, instead of using fping it now uses a topic publishing the roscore's clock and checks to see if there is a difference between the last received time and the most recent time on the topic. 

This has been tested with extrm and left running for a day with no crashes and the popup appearing when the battery got too low